### PR TITLE
Add an auto-sync config option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.2'
+def runeLiteVersion = '1.8.3'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/duckblade/osrs/dpscalc/DpsCalcConfig.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/DpsCalcConfig.java
@@ -16,4 +16,14 @@ public interface DpsCalcConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "enableAutoSync",
+			name = "Enable Auto Sync",
+			description = "Automatically sync game state to the panel as it changes"
+	)
+	default boolean enableAutoSync()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/duckblade/osrs/dpscalc/DpsCalcPlugin.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/DpsCalcPlugin.java
@@ -148,13 +148,12 @@ public class DpsCalcPlugin extends Plugin
 	{
 		if (!config.enableAutoSync()) return;
 
-		if (
-				statChanged.getSkill() == Skill.ATTACK ||
-				statChanged.getSkill() == Skill.STRENGTH ||
-				statChanged.getSkill() == Skill.DEFENCE ||
-				statChanged.getSkill() == Skill.MAGIC ||
-				statChanged.getSkill() == Skill.RANGED ||
-				statChanged.getSkill() == Skill.PRAYER
+		if (statChanged.getSkill() == Skill.ATTACK ||
+			statChanged.getSkill() == Skill.STRENGTH ||
+			statChanged.getSkill() == Skill.DEFENCE ||
+			statChanged.getSkill() == Skill.MAGIC ||
+			statChanged.getSkill() == Skill.RANGED ||
+			statChanged.getSkill() == Skill.PRAYER
 		) {
 			panel.onStatChanged();
 		}

--- a/src/main/java/com/duckblade/osrs/dpscalc/DpsCalcPlugin.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/DpsCalcPlugin.java
@@ -136,6 +136,7 @@ public class DpsCalcPlugin extends Plugin
 			panel.onEquipmentChanged();
 		}
 
+		// Unsure which varbit this actually is, or if its even defined anywhere
 		if (event.getIndex() == 83) {
 			panel.onPrayersChanged();
 		}
@@ -190,38 +191,5 @@ public class DpsCalcPlugin extends Plugin
 	DpsCalcConfig provideConfig(ConfigManager configManager)
 	{
 		return configManager.getConfig(DpsCalcConfig.class);
-	}
-
-	public boolean prayerVarbitChanged(int varbit) {
-		return varbit == Varbits.QUICK_PRAYER.getId() ||
-			varbit == Varbits.PRAYER_THICK_SKIN.getId() ||
-			varbit == Varbits.PRAYER_BURST_OF_STRENGTH.getId() ||
-			varbit == Varbits.PRAYER_CLARITY_OF_THOUGHT.getId() ||
-			varbit == Varbits.PRAYER_SHARP_EYE.getId() ||
-			varbit == Varbits.PRAYER_MYSTIC_WILL.getId() ||
-			varbit == Varbits.PRAYER_ROCK_SKIN.getId() ||
-			varbit == Varbits.PRAYER_SUPERHUMAN_STRENGTH.getId() ||
-			varbit == Varbits.PRAYER_IMPROVED_REFLEXES.getId() ||
-			varbit == Varbits.PRAYER_RAPID_RESTORE.getId() ||
-			varbit == Varbits.PRAYER_RAPID_HEAL.getId() ||
-			varbit == Varbits.PRAYER_PROTECT_ITEM.getId() ||
-			varbit == Varbits.PRAYER_HAWK_EYE.getId() ||
-			varbit == Varbits.PRAYER_MYSTIC_LORE.getId() ||
-			varbit == Varbits.PRAYER_STEEL_SKIN.getId() ||
-			varbit == Varbits.PRAYER_ULTIMATE_STRENGTH.getId() ||
-			varbit == Varbits.PRAYER_INCREDIBLE_REFLEXES.getId() ||
-			varbit == Varbits.PRAYER_PROTECT_FROM_MAGIC.getId() ||
-			varbit == Varbits.PRAYER_PROTECT_FROM_MISSILES.getId() ||
-			varbit == Varbits.PRAYER_PROTECT_FROM_MELEE.getId() ||
-			varbit == Varbits.PRAYER_EAGLE_EYE.getId() ||
-			varbit == Varbits.PRAYER_MYSTIC_MIGHT.getId() ||
-			varbit == Varbits.PRAYER_RETRIBUTION.getId() ||
-			varbit == Varbits.PRAYER_REDEMPTION.getId() ||
-			varbit == Varbits.PRAYER_SMITE.getId() ||
-			varbit == Varbits.PRAYER_CHIVALRY.getId() ||
-			varbit == Varbits.PRAYER_PIETY.getId() ||
-			varbit == Varbits.PRAYER_PRESERVE.getId() ||
-			varbit == Varbits.PRAYER_RIGOUR.getId() ||
-			varbit == Varbits.PRAYER_AUGURY.getId();
 	}
 }

--- a/src/main/java/com/duckblade/osrs/dpscalc/model/Prayer.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/model/Prayer.java
@@ -2,12 +2,12 @@ package com.duckblade.osrs.dpscalc.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.runelite.api.Varbits;
 
 @RequiredArgsConstructor
 @Getter
 public enum Prayer
 {
-
 	THICK_SKIN("Thick Skin", PrayerGroup.UTILITY, 1f, 1f, 3),
 	BURST_OF_STRENGTH("Burst of Strength", PrayerGroup.MELEE, 1f, 1.05f, 3),
 	CLARITY_OF_THOUGHT("Clarity of Thought", PrayerGroup.MELEE, 1.05f, 1f, 3),
@@ -25,7 +25,7 @@ public enum Prayer
 	ULTIMATE_STRENGTH("Ultimate Strength", PrayerGroup.MELEE, 1f, 1.15f, 12),
 	INCREDIBLE_REFLEXES("Incredible Reflexes", PrayerGroup.MELEE, 1.15f, 1f, 12),
 	PROTECT_FROM_MAGIC("Protect from Magic", PrayerGroup.UTILITY, 1f, 1.05f, 12),
-	PROTECT_FROM_RANGED("Protect from Missiles", PrayerGroup.UTILITY, 1f, 1.05f, 12),
+	PROTECT_FROM_MISSILES("Protect from Missiles", PrayerGroup.UTILITY, 1f, 1.05f, 12),
 	PROTECT_FROM_MELEE("Protect from Melee", PrayerGroup.UTILITY, 1f, 1.05f, 12),
 	EAGLE_EYE("Eagle Eye", PrayerGroup.RANGED, 1.15f, 1f, 12),
 	MYSTIC_MIGHT("Mystic Might", PrayerGroup.MAGE, 1.15f, 1f, 12),

--- a/src/main/java/com/duckblade/osrs/dpscalc/model/Prayer.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/model/Prayer.java
@@ -2,7 +2,6 @@ package com.duckblade.osrs.dpscalc.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.Varbits;
 
 @RequiredArgsConstructor
 @Getter

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/DpsCalcPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/DpsCalcPanel.java
@@ -62,6 +62,11 @@ public class DpsCalcPanel extends JPanel
 		this.prayerPanel = prayerPanel;
 		this.resultPanel = resultPanel;
 
+		this.npcStatsPanel.setOnUpdated(this::updateNav);
+		this.equipmentPanel.setOnUpdated(this::updateNav);
+		this.skillsPanel.setOnUpdated(this::updateNav);
+		this.prayerPanel.setOnUpdated(this::updateNav);
+
 		this.panelId = Integer.toString(panelIdGenerator.getAndIncrement());
 
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -80,6 +85,7 @@ public class DpsCalcPanel extends JPanel
 		equipmentNav = new MenuPanelNavEntry("Equipment", "Not Set", this::openEquipment);
 		menuPanel.add(equipmentNav);
 		menuPanel.add(Box.createVerticalStrut(5));
+
 
 		skillsNav = new MenuPanelNavEntry("Skills", "Not Set", this::openSkills);
 		menuPanel.add(skillsNav);
@@ -189,4 +195,36 @@ public class DpsCalcPanel extends JPanel
 		});
 	}
 
+	public void onEquipmentChanged()
+	{
+		equipmentPanel.loadFromClient();
+	}
+	public void onPrayersChanged()
+	{
+		prayerPanel.loadFromClient();
+	}
+
+	public void onStatChanged()
+	{
+		skillsPanel.loadFromClient();
+	}
+
+
+	public void onTargetChanged(NpcStats stats)
+	{
+		npcStatsPanel.loadNpcStats(stats);
+	}
+
+	public void updateNav() {
+		SwingUtilities.invokeLater(() ->
+		{
+			npcStatsNav.setDescription(npcStatsPanel.getSummary());
+			equipmentNav.setDescription(equipmentPanel.getSummary());
+			skillsNav.setDescription(skillsPanel.getSummary());
+			prayerNav.setDescription(prayerPanel.getSummary());
+			calculateDps();
+			revalidate();
+			repaint();
+		});
+	}
 }

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/DpsCalcPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/DpsCalcPanel.java
@@ -86,7 +86,6 @@ public class DpsCalcPanel extends JPanel
 		menuPanel.add(equipmentNav);
 		menuPanel.add(Box.createVerticalStrut(5));
 
-
 		skillsNav = new MenuPanelNavEntry("Skills", "Not Set", this::openSkills);
 		menuPanel.add(skillsNav);
 		menuPanel.add(Box.createVerticalStrut(5));
@@ -208,7 +207,6 @@ public class DpsCalcPanel extends JPanel
 	{
 		skillsPanel.loadFromClient();
 	}
-
 
 	public void onTargetChanged(NpcStats stats)
 	{

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/DpsPluginPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/DpsPluginPanel.java
@@ -22,6 +22,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
+
+import net.runelite.api.NPC;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
@@ -119,4 +121,23 @@ public class DpsPluginPanel extends PluginPanel
 		currentPanel.openNpcStats(preload);
 	}
 
+	public void onEquipmentChanged()
+	{
+		inputPanels.forEach(DpsCalcPanel::onEquipmentChanged);
+	}
+
+	public void onPrayersChanged()
+	{
+		inputPanels.forEach(DpsCalcPanel::onPrayersChanged);
+	}
+
+	public void onStatChanged()
+	{
+		inputPanels.forEach(DpsCalcPanel::onStatChanged);
+	}
+
+	public void onTargetChanged(NpcStats target)
+	{
+		inputPanels.forEach(p -> p.onTargetChanged(target));
+	}
 }

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/equip/EquipmentPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/equip/EquipmentPanel.java
@@ -22,14 +22,9 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
+import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.GameState;
@@ -67,6 +62,9 @@ public class EquipmentPanel extends JPanel
 	private final JTextField dharokMaxHpField;
 
 	private final JPanel totalsPanel;
+
+	@Setter
+	private Runnable onUpdated;
 
 	@Inject
 	public EquipmentPanel(@Nullable Client client, @Nullable ClientThread clientThread, @Nullable ItemManager rlItemManager, ItemDataManager itemDataManager)
@@ -375,6 +373,7 @@ public class EquipmentPanel extends JPanel
 			rebuildTotals();
 			revalidate();
 			repaint();
+			onUpdated.run();
 		});
 	}
 	

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/npc/NpcStatsPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/npc/NpcStatsPanel.java
@@ -14,13 +14,10 @@ import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 
 import lombok.Setter;
-import net.runelite.api.Client;
 import net.runelite.client.ui.PluginPanel;
 
 public class NpcStatsPanel extends JPanel
 {
-	private final Client client;
-
 	private final CustomJCheckBox manualEntry;
 	private final CustomJComboBox<NpcStats> npcSelect;
 
@@ -31,9 +28,8 @@ public class NpcStatsPanel extends JPanel
 	private Runnable onUpdated;
 
 	@Inject
-	public NpcStatsPanel(Client client, NpcDataManager npcDataManager)
+	public NpcStatsPanel(NpcDataManager npcDataManager)
 	{
-		this.client = client;
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
 		manualEntry = new CustomJCheckBox("Manual Entry Mode");

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/npc/NpcStatsPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/npc/NpcStatsPanel.java
@@ -12,10 +12,14 @@ import javax.inject.Inject;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JPanel;
+
+import lombok.Setter;
+import net.runelite.api.Client;
 import net.runelite.client.ui.PluginPanel;
 
 public class NpcStatsPanel extends JPanel
 {
+	private final Client client;
 
 	private final CustomJCheckBox manualEntry;
 	private final CustomJComboBox<NpcStats> npcSelect;
@@ -23,9 +27,13 @@ public class NpcStatsPanel extends JPanel
 	private final List<NpcStatBox> statBoxes;
 	private final List<NpcCheckBox> flagChecks;
 
+	@Setter
+	private Runnable onUpdated;
+
 	@Inject
-	public NpcStatsPanel(NpcDataManager npcDataManager)
+	public NpcStatsPanel(Client client, NpcDataManager npcDataManager)
 	{
+		this.client = client;
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
 		manualEntry = new CustomJCheckBox("Manual Entry Mode");
@@ -121,6 +129,8 @@ public class NpcStatsPanel extends JPanel
 	{
 		statBoxes.forEach(sb -> sb.setValue(stats));
 		flagChecks.forEach(fc -> fc.setValue(stats));
+
+		onUpdated.run();
 	}
 
 	private void setAllEditable(boolean editable)

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/prayer/PrayerPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/prayer/PrayerPanel.java
@@ -11,17 +11,26 @@ import javax.inject.Inject;
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+
+import lombok.Setter;
+import net.runelite.api.Client;
 import net.runelite.client.ui.PluginPanel;
 
 public class PrayerPanel extends JPanel
 {
+	private final Client client;
 
 	private final JLabel drainLabel;
 	private final Map<Prayer, PrayerButton> prayerButtons;
 
+	@Setter
+	private Runnable onUpdated;
+
 	@Inject
-	public PrayerPanel()
+	public PrayerPanel(Client client)
 	{
+		this.client = client;
+
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setMinimumSize(new Dimension(PluginPanel.PANEL_WIDTH, 0));
 
@@ -55,6 +64,14 @@ public class PrayerPanel extends JPanel
 	private void updateDrainLabel()
 	{
 		drainLabel.setText("Total Drain: " + getDrain());
+		onUpdated.run();
+	}
+
+	public void loadFromClient() {
+		for (Prayer p: Prayer.values()) {
+			prayerButtons.get(p).setSelected(client.isPrayerActive(net.runelite.api.Prayer.valueOf(p.toString())));
+		}
+		updateDrainLabel();
 	}
 
 	public List<Prayer> getSelected()

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/skills/SkillsPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/skills/SkillsPanel.java
@@ -140,7 +140,7 @@ public class SkillsPanel extends JPanel
 	public Map<Skill, Integer> getBoosts()
 	{
 
-		Map<Skill, Integer> results = new HashMap<>(5);
+		Map<Skill, Integer> results = new HashMap<>(6);
 		boostBoxes.forEach((k, v) -> results.put(k, v.getValue()));
 		return results;
 	}

--- a/src/main/java/com/duckblade/osrs/dpscalc/ui/skills/SkillsPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/ui/skills/SkillsPanel.java
@@ -12,10 +12,9 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JPanel;
+import javax.swing.*;
+
+import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
@@ -32,6 +31,9 @@ public class SkillsPanel extends JPanel
 
 	private final Map<Skill, StatBox> statBoxes;
 	private final Map<Skill, StatBox> boostBoxes;
+
+	@Setter
+	private Runnable onUpdated;
 
 	@Inject
 	public SkillsPanel(@Nullable Client client, @Nullable ClientThread clientThread)
@@ -90,7 +92,7 @@ public class SkillsPanel extends JPanel
 		add(applyPresetButton);
 	}
 
-	private void loadFromClient()
+	public void loadFromClient()
 	{
 		if (client == null || clientThread == null)
 			return; // ui test
@@ -102,6 +104,9 @@ public class SkillsPanel extends JPanel
 				return;
 
 			statBoxes.forEach((skill, box) -> box.setValue(client.getRealSkillLevel(skill)));
+			boostBoxes.forEach((skill, box) -> box.setValue(client.getBoostedSkillLevel(skill) - client.getRealSkillLevel(skill)));
+
+			onUpdated.run();
 		});
 	}
 
@@ -135,7 +140,7 @@ public class SkillsPanel extends JPanel
 	public Map<Skill, Integer> getBoosts()
 	{
 
-		Map<Skill, Integer> results = new HashMap<>(6);
+		Map<Skill, Integer> results = new HashMap<>(5);
 		boostBoxes.forEach((k, v) -> results.put(k, v.getValue()));
 		return results;
 	}


### PR DESCRIPTION
Enabling this configuration allows the players target, skills, equipment, and prayer to sync from the client. These values are used to give a real time dps calculation for the current game state.