### PR TITLE
Crystal Armor Bonuses not applied for Crystal Bow/Bow of Faerdhinen (…

### DIFF
--- a/src/main/java/com/duckblade/osrs/dpscalc/calc/gearbonus/CrystalGearBonus.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/calc/gearbonus/CrystalGearBonus.java
@@ -33,15 +33,36 @@ public class CrystalGearBonus implements GearBonusComputable
 	);
 
 	private static final Set<Integer> CRYSTAL_HELM_IDS = ImmutableSet.of(
-		ItemID.CRYSTAL_HELM
+		ItemID.CRYSTAL_HELM,
+		ItemID.CRYSTAL_HELM_27705,
+		ItemID.CRYSTAL_HELM_27717,
+		ItemID.CRYSTAL_HELM_27729,
+		ItemID.CRYSTAL_HELM_27741,
+		ItemID.CRYSTAL_HELM_27753,
+		ItemID.CRYSTAL_HELM_27765,
+		ItemID.CRYSTAL_HELM_27777
 	);
 
 	private static final Set<Integer> CRYSTAL_BODY_IDS = ImmutableSet.of(
-		ItemID.CRYSTAL_BODY
+		ItemID.CRYSTAL_BODY,
+		ItemID.CRYSTAL_BODY_27697,
+		ItemID.CRYSTAL_BODY_27709,
+		ItemID.CRYSTAL_BODY_27721,
+		ItemID.CRYSTAL_BODY_27733,
+		ItemID.CRYSTAL_BODY_27745,
+		ItemID.CRYSTAL_BODY_27757,
+		ItemID.CRYSTAL_BODY_27769
 	);
 
 	private static final Set<Integer> CRYSTAL_LEGS_IDS = ImmutableSet.of(
-		ItemID.CRYSTAL_LEGS
+		ItemID.CRYSTAL_LEGS,
+		ItemID.CRYSTAL_LEGS_27701,
+		ItemID.CRYSTAL_LEGS_27713,
+		ItemID.CRYSTAL_LEGS_27725,
+		ItemID.CRYSTAL_LEGS_27737,
+		ItemID.CRYSTAL_LEGS_27749,
+		ItemID.CRYSTAL_LEGS_27761,
+		ItemID.CRYSTAL_LEGS_27773
 	);
 
 	private final EquipmentItemIdsComputable equipmentItemIdsComputable;


### PR DESCRIPTION
…#92)

* calc: Included recoloured variants of crystal armour in the crystal armour gear bonus.


I see there is already code to apply the crystal armour bonus. Given how recently this issue was created, I'm assuming the user is wearing a recoloured version of crystal armour, and the bug is simply that the IDs for these were missing and have to be added as they were for the bow.