### PR TITLE
Add warped sceptre max hit provider

### DIFF
--- a/src/main/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputable.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputable.java
@@ -29,12 +29,11 @@ public class PoweredStaffMaxHitComputable implements MagicMaxHitComputable
 		int magicLevel = ctx.get(ComputeInputs.ATTACKER_SKILLS).getTotals().get(Skill.MAGIC);
 		return Math.max(1, (magicLevel - 75) / 3 + 20);
 	};
-
-  private static final StaffMaxHitProvider WARPED = ctx ->
-  {
-    int magicLevel = ctx.get(ComputeInputs.ATTACKER_SKILLS).getTotals().get(Skill.MAGIC);
-    return Math.max(1, ((8* magicLevel) + 96) / 37);
-  };
+	private static final StaffMaxHitProvider WARPED = ctx ->
+	{
+		int magicLevel = ctx.get(ComputeInputs.ATTACKER_SKILLS).getTotals().get(Skill.MAGIC);
+		return Math.max(1, ((8 * magicLevel) + 96) / 37);
+	};
 
 	private static final StaffMaxHitProvider SWAMP = ctx -> SEAS.compute(ctx) + 3;
 	private static final StaffMaxHitProvider SANGUINESTI = ctx -> SEAS.compute(ctx) + 4;
@@ -56,7 +55,6 @@ public class PoweredStaffMaxHitComputable implements MagicMaxHitComputable
 		.put(ItemID.CRYSTAL_STAFF_PERFECTED, ignored -> 39)
 		.put(ItemID.CORRUPTED_STAFF_PERFECTED, ignored -> 39)
     .put(ItemID.WARPED_SCEPTRE, WARPED)
-    .put(ItemID.WARPED_SCEPTRE_UNCHARGED, WARPED)
 		.build();
 
 	private final WeaponComputable weaponComputable;

--- a/src/main/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputable.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputable.java
@@ -29,6 +29,13 @@ public class PoweredStaffMaxHitComputable implements MagicMaxHitComputable
 		int magicLevel = ctx.get(ComputeInputs.ATTACKER_SKILLS).getTotals().get(Skill.MAGIC);
 		return Math.max(1, (magicLevel - 75) / 3 + 20);
 	};
+
+  private static final StaffMaxHitProvider WARPED = ctx ->
+  {
+    int magicLevel = ctx.get(ComputeInputs.ATTACKER_SKILLS).getTotals().get(Skill.MAGIC);
+    return Math.max(1, ((8* magicLevel) + 96) / 37);
+  };
+
 	private static final StaffMaxHitProvider SWAMP = ctx -> SEAS.compute(ctx) + 3;
 	private static final StaffMaxHitProvider SANGUINESTI = ctx -> SEAS.compute(ctx) + 4;
 	private static final StaffMaxHitProvider SHADOW = ctx -> SEAS.compute(ctx) + 6;
@@ -48,6 +55,8 @@ public class PoweredStaffMaxHitComputable implements MagicMaxHitComputable
 		.put(ItemID.CORRUPTED_STAFF_ATTUNED, ignored -> 31)
 		.put(ItemID.CRYSTAL_STAFF_PERFECTED, ignored -> 39)
 		.put(ItemID.CORRUPTED_STAFF_PERFECTED, ignored -> 39)
+    .put(ItemID.WARPED_SCEPTRE, WARPED)
+    .put(ItemID.WARPED_SCEPTRE_UNCHARGED, WARPED)
 		.build();
 
 	private final WeaponComputable weaponComputable;

--- a/src/main/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputable.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputable.java
@@ -54,7 +54,7 @@ public class PoweredStaffMaxHitComputable implements MagicMaxHitComputable
 		.put(ItemID.CORRUPTED_STAFF_ATTUNED, ignored -> 31)
 		.put(ItemID.CRYSTAL_STAFF_PERFECTED, ignored -> 39)
 		.put(ItemID.CORRUPTED_STAFF_PERFECTED, ignored -> 39)
-    .put(ItemID.WARPED_SCEPTRE, WARPED)
+		.put(ItemID.WARPED_SCEPTRE, WARPED)
 		.build();
 
 	private final WeaponComputable weaponComputable;

--- a/src/test/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputableTest.java
+++ b/src/test/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputableTest.java
@@ -109,8 +109,7 @@ class PoweredStaffMaxHitComputableTest
 	void givesMaxHitForWarpedSceptre()
 	{
 		when(context.get(weaponComputable)).thenReturn(
-				ofItemId(ItemID.WARPED_SCEPTRE),
-				ofItemId(ItemID.WARPED_SCEPTRE_UNCHARGED)
+				ofItemId(ItemID.WARPED_SCEPTRE)
 		);
 		when(context.get(ComputeInputs.ATTACKER_SKILLS)).thenReturn(
 				ofSkill(Skill.MAGIC, 0),

--- a/src/test/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputableTest.java
+++ b/src/test/java/com/duckblade/osrs/dpscalc/calc/maxhit/magic/PoweredStaffMaxHitComputableTest.java
@@ -106,6 +106,22 @@ class PoweredStaffMaxHitComputableTest
 	}
 
 	@Test
+	void givesMaxHitForWarpedSceptre()
+	{
+		when(context.get(weaponComputable)).thenReturn(
+				ofItemId(ItemID.WARPED_SCEPTRE),
+				ofItemId(ItemID.WARPED_SCEPTRE_UNCHARGED)
+		);
+		when(context.get(ComputeInputs.ATTACKER_SKILLS)).thenReturn(
+				ofSkill(Skill.MAGIC, 0),
+				ofSkill(Skill.MAGIC, 99)
+		);
+
+		assertEquals(2, poweredStaffMaxHitComputable.compute(context));
+		assertEquals(24, poweredStaffMaxHitComputable.compute(context));
+	}
+
+	@Test
 	void givesMaxHitForSangStaff()
 	{
 		when(context.get(weaponComputable)).thenReturn(


### PR DESCRIPTION
Now that the DB is updated we also need to add the sceptre's max hit provider to properly calculate DPS.