### PR TITLE
ui: Fix attack style resetting to null on switching sets

### DIFF
--- a/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/state/component/StateBoundJComboBox.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/state/component/StateBoundJComboBox.java
@@ -29,19 +29,6 @@ public class StateBoundJComboBox<T> extends CustomJComboBox<T> implements StateB
 	}
 
 	@Override
-	public void setItems(List<T> newItems)
-	{
-		T prev = getValue();
-		super.setItems(newItems);
-
-		// setItems can update value, so we propagate any changes to state immediately
-		if (!Objects.equals(prev, getValue()))
-		{
-			toState();
-		}
-	}
-
-	@Override
 	public void toState()
 	{
 		if (stateWriter != null)


### PR DESCRIPTION
When the JComboBox items get updated for the attack styles combo box (which happens when you switch weapons or switch sets), the state is always overwritten with null.  This is caused by the unnecessary function override `StateBoundJComboBox::setItems` which adds:
```
if (!Objects.equals(prev, getValue()))
{
	toState();
}
```
In the if statement, `getValue()` always evaluates to null because the above call to `super.setItems` clears the combobox entries and refills them from scratch, thus resetting the selectedIndex to 0. 

You can validate this by adding `super.setNullLast(true);` to the `AttackStyleSelectPanel` constructor and observing that the attack style always resets to the first one in the list instead of null