### PR TITLE
ui: Fix attack style resets to null on switching sets

### DIFF
--- a/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/equip/AttackStyleSelectPanel.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/equip/AttackStyleSelectPanel.java
@@ -15,7 +15,6 @@ import net.runelite.api.EquipmentInventorySlot;
 @Singleton
 public class AttackStyleSelectPanel extends StateBoundJComboBox<AttackStyle>
 {
-
 	private WeaponCategory previousWeaponCategory = null;
 
 	@Inject
@@ -37,26 +36,25 @@ public class AttackStyleSelectPanel extends StateBoundJComboBox<AttackStyle>
 	@Override
 	public void fromState()
 	{
-		if (previousWeaponCategory != (previousWeaponCategory = currentWeaponCategory()))
-		{
-			List<AttackStyle> weaponStyles = getState().getAttackerItems()
+		WeaponCategory currentWeaponCategory = getState().getAttackerItems()
 				.getOrDefault(EquipmentInventorySlot.WEAPON, ItemStats.EMPTY)
-				.getWeaponCategory()
-				.getAttackStyles();
+				.getWeaponCategory();
 
-			List<AttackStyle> selectableStyles = new ArrayList<>(weaponStyles.size() + 1);
-			selectableStyles.addAll(weaponStyles);
+		if (previousWeaponCategory != (previousWeaponCategory = currentWeaponCategory))
+		{
+			List<AttackStyle> selectableStyles = new ArrayList<>(currentWeaponCategory.getAttackStyles().size() + 1);
+			selectableStyles.addAll(currentWeaponCategory.getAttackStyles());
+			// No matter the weapon, you can always manually cast spells
 			selectableStyles.add(AttackStyle.MANUAL_CAST);
 			setItems(selectableStyles);
+
+			// reset attack style if it is no longer valid
+			if (!selectableStyles.contains(getState().getAttackStyle()))
+			{
+				getState().setAttackStyle(null);
+			}
 		}
 
 		super.fromState();
-	}
-
-	private WeaponCategory currentWeaponCategory()
-	{
-		return getState().getAttackerItems()
-			.getOrDefault(EquipmentInventorySlot.WEAPON, ItemStats.EMPTY)
-			.getWeaponCategory();
 	}
 }

--- a/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/state/component/StateBoundJComboBox.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/state/component/StateBoundJComboBox.java
@@ -5,7 +5,6 @@ import com.duckblade.osrs.dpscalc.plugin.ui.state.PanelStateManager;
 import com.duckblade.osrs.dpscalc.plugin.ui.state.StateBoundComponent;
 import com.duckblade.osrs.dpscalc.plugin.ui.util.CustomJComboBox;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import lombok.Getter;
@@ -26,19 +25,6 @@ public class StateBoundJComboBox<T> extends CustomJComboBox<T> implements StateB
 		this.stateWriter = stateWriter;
 		this.stateReader = stateReader;
 		addCallback(this::toState);
-	}
-
-	@Override
-	public void setItems(List<T> newItems)
-	{
-		T prev = getValue();
-		super.setItems(newItems);
-
-		// setItems can update value, so we propagate any changes to state immediately
-		if (!Objects.equals(prev, getValue()))
-		{
-			toState();
-		}
 	}
 
 	@Override

--- a/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/util/CustomJComboBox.java
+++ b/src/main/java/com/duckblade/osrs/dpscalc/plugin/ui/util/CustomJComboBox.java
@@ -152,14 +152,14 @@ public class CustomJComboBox<T> extends JPanel
 	public void setValue(T newValue)
 	{
 		callbackEnabled = false;
+		if (!isValidValue(newValue))
+		{
+			callbackEnabled = true;
+			throw new IllegalArgumentException(newValue + " does not exist in items");
+		}
+
 		if (newValue == null)
 		{
-			if (!allowNull)
-			{
-				callbackEnabled = true;
-				throw new IllegalArgumentException(newValue + " does not exist in items");
-			}
-
 			int nullIx = nullLast ? items.size() : 0;
 			comboBox.setSelectedIndex(nullIx);
 		}
@@ -169,6 +169,16 @@ public class CustomJComboBox<T> extends JPanel
 			comboBox.setSelectedIndex(items.indexOf(newValue) + nullOffset);
 		}
 		callbackEnabled = true;
+	}
+
+	public boolean isValidValue(T newValue)
+	{
+		if (newValue == null)
+		{
+			return allowNull;
+		}
+
+		return items.contains(newValue);
 	}
 
 	public void addBottomPadding(int height)


### PR DESCRIPTION
Fixes Issue #116

## Bug Description
When the `JComboBox` items get updated for the attack styles combo box (which happens when you switch weapons or switch sets), the state is always overwritten with null. 

## The Fix
Refactored the logic to check for valid AttackStyle after doing `setItems` regularly, rather than the status quo of overriding `setItems` to have a side-effect.

Also added `isValidValue` function to `CustomJComboBox` to check for both unexpected null parameter and parameters that are not included in the options.